### PR TITLE
Keep trailing slash on generated path

### DIFF
--- a/src/generate-path.ts
+++ b/src/generate-path.ts
@@ -57,6 +57,9 @@ export function generatePath<Path extends string>(
   // ensure `/` is added at the beginning if the path is absolute
   const prefix = path.startsWith("/") ? "/" : "";
 
+  // ensure '/' is addded at the end if the path was declared so
+  const trailingSlash = path.endsWith('/') ? '/' : ''
+
   const segments = path
     .split(/\/+/)
     .map((segment, index, array) => {
@@ -93,7 +96,7 @@ export function generatePath<Path extends string>(
     // Remove empty segments
     .filter((segment) => !!segment);
 
-  return prefix + segments.join("/");
+  return prefix + segments.join("/") + trailingSlash;
 }
 
 function invariant(value: boolean, message?: string): asserts value;


### PR DESCRIPTION
If a path is defined with a trailing slash it should not be removed. This is important for backend frameworks like Django, which prefer trailing slashes on URLs by default.